### PR TITLE
[FEATURE] Also replace html in uncached content

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,10 @@
 <?php
 defined('TYPO3_MODE') or die();
 
-// Register hook
+// Register hook for cached content
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][] =
+    \JWeiland\Replacer\Hooks\TypoScriptFrontendController::class . '->contentPostProcAll';
+
+// Register hook for uncached content (USER_INT, uncached extbase actions, etc...)
+$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] =
     \JWeiland\Replacer\Hooks\TypoScriptFrontendController::class . '->contentPostProcAll';


### PR DESCRIPTION
Hi,

At the moment it's not possible to use the replace function in the output of uncached extbase extensions or in content from type USER_INT or COA_INT. Adding a second hook will ensure this.

If you don't want this because of unwanted side-effects, you could also toggle this feature with extension-manager settings?

Cheers from Rosenheim