### PR TITLE
[TASK] Fix dependency problem with TYPO3 9.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "source": "https://github.com/jweiland-net/replacer"
   },
   "require": {
-    "typo3/cms-core": ">=7.6,<=9.5"
+    "typo3/cms-core": "^7.6 || ^8.7 || ^9.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The previous version condition caused problems with TYPO3 > 9.5.0. `9.5.*` didn't work, so we switched to the way EXT:news uses.

https://github.com/georgringer/news/blob/master/composer.json#L21