### PR TITLE
[OPT] Middleware Hook

### DIFF
--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -5,7 +5,7 @@ return [
         'jweiland/replacer/replace-content' => [
             'target' => \JWeiland\Replacer\Middleware\ReplaceContent::class,
             'after' => [
-                'typo3/cms-frontend/maintenance-mode'
+                'typo3/cms-frontend/content-length-headers'
             ]
         ]
     ]


### PR DESCRIPTION
will be executed right before the `content-length-headers` calculation