### PR TITLE
Bugfix: TSFE->cObj not available on shortcut pages

### DIFF
--- a/Classes/Middleware/ReplaceContentMiddleware.php
+++ b/Classes/Middleware/ReplaceContentMiddleware.php
@@ -39,7 +39,10 @@ class ReplaceContentMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
-        if (!$this->getTypoScriptFrontendController()->isINTincScript() || $response instanceof NullResponse) {
+        if (!$this->getTypoScriptFrontendController()->isINTincScript()
+            || $response instanceof NullResponse
+            || $this->getContentObjectRenderer() === null
+        ) {
             return $response;
         }
 

--- a/Classes/Traits/GetTypoScriptFrontendControllerTrait.php
+++ b/Classes/Traits/GetTypoScriptFrontendControllerTrait.php
@@ -29,7 +29,7 @@ trait GetTypoScriptFrontendControllerTrait
         return $GLOBALS['TSFE'];
     }
 
-    protected function getContentObjectRenderer(): ContentObjectRenderer
+    protected function getContentObjectRenderer(): ?ContentObjectRenderer
     {
         return $this->getTypoScriptFrontendController()->cObj;
     }


### PR DESCRIPTION
This fixes the TypeError

JWeiland\Replacer\Helper\TypoScriptHelper::getContentObjectRenderer(): Return value must be of type TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer, null returned

that occurs, when you visit a shortcut page with its original slug.

Resolves: #2